### PR TITLE
Consistent state

### DIFF
--- a/backend/data_collection_system/gui.py
+++ b/backend/data_collection_system/gui.py
@@ -302,11 +302,11 @@ class Gui(wx.Frame):
     async def on_change_setup(self, event):
         """Handle the event when the user changes the setup control
         value. """
-        status = await self.client.update_setup(SetupOptions(event.GetInt()))
-        if not status:  # If unsuccessful, revert to original selection
-            self.setup.SetSelection(
-                self.setup.FindString(str(self.client.configuration.setup))
+        self.setup.SetSelection(
+            self.setup.FindString(
+                str(await self.client.update_setup(SetupOptions(event.GetInt())))
             )
+        )
 
     async def update_status(self):
         while self.client.connected:

--- a/backend/data_collection_system/x55/x55_client.py
+++ b/backend/data_collection_system/x55/x55_client.py
@@ -133,6 +133,8 @@ class Configuration:
 
         logger.info("Loaded configuration from database")
 
+        return self.setup
+
     def parse(self, config_file):
         """
         Parse and save a configuration to the database metadata tables.
@@ -353,7 +355,7 @@ class x55Client:
         return self.peak_data_streaming_divider
 
     async def update_setup(self, setup: SetupOptions) -> bool:
-        self.configuration.load(setup)
+        return self.configuration.load(setup)
 
     async def stream(self):
         await self.peaks.connect()


### PR DESCRIPTION
- On setting the new laser scan speed, divider or setup, get and return the new value from the optical instrument to better ensure that the program state is consistent with the instrument state.